### PR TITLE
Updated Module and Lesson post types on marketing frontend to accept references to parent and grandparent posts.

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -169,6 +169,7 @@ class ChapterAdmin(admin.ModelAdmin):
         return actions
 
     delete_error = False
+    save_error = False
 
     def delete_selected(self, request, obj):
         for o in obj.all():
@@ -182,6 +183,18 @@ class ChapterAdmin(admin.ModelAdmin):
 
                 msg = DELETION_FAILURE_MSG_TPL.format(model='chapter')  # pylint: disable=no-member
                 messages.add_message(request, messages.ERROR, msg)
+
+    def save_model(self, request, obj, form, change):
+        try:
+            obj.status = ChapterStatus.Unpublished
+            obj.save(is_published=False)
+        except (MarketingSitePublisherException, MarketingSiteAPIClientException):
+            self.save_error = True
+
+            logger.exception('An error occurred while publishing chapter [%s] to the marketing site.', obj.uuid)
+
+            msg = PUBLICATION_FAILURE_MSG_TPL.format(model='chapter')  # pylint: disable=no-member
+            messages.add_message(request, messages.ERROR, msg)
 
 
 @admin.register(Sequential)

--- a/course_discovery/apps/course_metadata/publishers_wordpress.py
+++ b/course_discovery/apps/course_metadata/publishers_wordpress.py
@@ -553,11 +553,18 @@ class SequentialMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublis
             }
         )
 
+        module_post_id = None
+        for related_chapter in obj.chapters.all():
+            if related_chapter and obj.course_run.key == related_chapter.course_run.key:
+                module_post_id = related_chapter.wordpress_post_id
+
         data['fields'][self.post_lookup_meta_group].update(
             {
                 # 'registration_url': "{base}/register?course_id={course_id}&enrollment_action=enroll".format(base=self.partner.lms_url, course_id=str(getattr(obj, self.unique_field))),
                 # 'card_image_url': obj.card_image_url
-                'lms_web_url': obj.lms_web_url
+                'lms_web_url': obj.lms_web_url,
+                'course_post': obj.course_run.wordpress_post_id,
+                'module_post': module_post_id,
             }
         )
 
@@ -649,7 +656,8 @@ class ChapterMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublisher
             {
                 # 'registration_url': "{base}/register?course_id={course_id}&enrollment_action=enroll".format(base=self.partner.lms_url, course_id=str(getattr(obj, self.unique_field))),
                 # 'card_image_url': obj.card_image_url
-                'lms_web_url': obj.lms_web_url
+                'lms_web_url': obj.lms_web_url,
+                'course_post': obj.course_run.wordpress_post_id,
             }
         )
 


### PR DESCRIPTION
To ensure that the `Module` post type search can get reference to it's parent `Course` post type it needs to have that reference within the post.