### PR TITLE
Added support for tags to Sequential, Chapter, and CourseRun models.

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -187,7 +187,7 @@ class ChapterAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         try:
             obj.status = ChapterStatus.Unpublished
-            obj.save(is_published=False)
+            obj.save(is_published=False, is_child_update=True)
         except (MarketingSitePublisherException, MarketingSiteAPIClientException):
             self.save_error = True
 
@@ -238,7 +238,7 @@ class SequentialAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         try:
             obj.status = SequentialStatus.Unpublished
-            obj.save(is_published=False)
+            obj.save(is_published=False, is_child_update=True)
         except (MarketingSitePublisherException, MarketingSiteAPIClientException):
             self.save_error = True
 

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -92,7 +92,7 @@ class CourseRunAdmin(admin.ModelAdmin):
         'status',
     )
     ordering = ('key',)
-    readonly_fields = ('uuid', 'wordpress_post_id', 'min_effort', 'max_effort',)
+    readonly_fields = ('uuid', 'wordpress_post_id', 'min_effort', 'max_effort', 'tags',)
     search_fields = ('uuid', 'wordpress_post_id', 'key', 'title_override', 'course__title', 'slug',)
 
     # ordering the field display on admin page.
@@ -152,13 +152,13 @@ class ChapterAdmin(admin.ModelAdmin):
     list_display = ('uuid', 'hidden', 'wordpress_post_id', 'min_effort', 'max_effort', 'title', 'slug', 'course_order', 'location')
     list_filter = ('hidden', 'status', 'title',)
     ordering = ('location', 'title',)
-    readonly_fields = ('uuid', 'course_run', 'location', 'wordpress_post_id', 'min_effort', 'max_effort',)
+    readonly_fields = ('uuid', 'course_run', 'location', 'wordpress_post_id', 'min_effort', 'max_effort', 'tags',)
     search_fields = ('uuid', 'title', 'slug', 'location',)
 
     # ordering the field display on admin page.
     fields = (
         'course_run', 'location', 'status', 'title', 'lms_web_url', 'goal_override', 'sequentials', 'min_effort', 'max_effort',
-        'course_order', 'slug', 'hidden', 'wordpress_post_id', 'uuid'
+        'course_order', 'slug', 'hidden', 'tags', 'wordpress_post_id', 'uuid'
     )
 
     actions = ['delete_selected']
@@ -209,7 +209,7 @@ class SequentialAdmin(admin.ModelAdmin):
     # ordering the field display on admin page.
     fields = (
         'course_run', 'location', 'status', 'title', 'lms_web_url', 'objectives', 'min_effort', 'max_effort',
-        'chapter_order', 'slug', 'hidden', 'wordpress_post_id', 'uuid'
+        'chapter_order', 'slug', 'hidden', 'tags', 'wordpress_post_id', 'uuid'
     )
 
     actions = ['delete_selected']
@@ -246,6 +246,10 @@ class SequentialAdmin(admin.ModelAdmin):
 
             msg = PUBLICATION_FAILURE_MSG_TPL.format(model='sequential')  # pylint: disable=no-member
             messages.add_message(request, messages.ERROR, msg)
+
+    # def save_related(self, request, form, formsets, change):
+    #     super(SequentialAdmin, self).save_related(request, form, formsets, change)
+        # form.instance.tags.add('999')
 
 
 @admin.register(Objective)

--- a/course_discovery/apps/course_metadata/exceptions.py
+++ b/course_discovery/apps/course_metadata/exceptions.py
@@ -61,3 +61,6 @@ class PostDeleteError(MarketingSitePublisherException):
 #
 # class MediaCreateError(MarketingSitePublisherException):
 #     pass
+
+class TagCreateError(MarketingSitePublisherException):
+    pass

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -740,6 +740,8 @@ class CourseRun(TimeStampedModel):
     def save(self, *args, **kwargs):
         suppress_publication = kwargs.pop('suppress_publication', False)
         is_published = kwargs.pop('is_published', False)
+        ignore_tag_creation = kwargs.pop('ignore_tag_creation', True)
+
         is_publishable = (
             self.course.partner.has_marketing_site and
             waffle.switch_is_active('publish_course_runs_to_marketing_site') and
@@ -758,7 +760,7 @@ class CourseRun(TimeStampedModel):
 
             with transaction.atomic():
                 super(CourseRun, self).save(*args, **kwargs)
-                publisher.publish_obj(self, previous_obj=previous_obj)
+                publisher.publish_obj(self, previous_obj=previous_obj, ignore_tag_creation=ignore_tag_creation)
 
         else:
             if is_published:
@@ -939,6 +941,9 @@ class Chapter(TimeStampedModel):
         #Todo: Need to come back and update this for publishing to Wordpress frontend on save.
         suppress_publication = kwargs.pop('suppress_publication', False)
         is_published = kwargs.pop('is_published', False)
+        is_child_update = kwargs.pop('is_child_update', False)
+        ignore_tag_creation = kwargs.pop('ignore_tag_creation', True)
+
         is_publishable = (
             self.course_run.course.partner.has_marketing_site and
             waffle.switch_is_active('publish_course_runs_to_marketing_site') and
@@ -957,7 +962,7 @@ class Chapter(TimeStampedModel):
 
             with transaction.atomic():
                 super(Chapter, self).save(*args, **kwargs)
-                publisher.publish_obj(self, previous_obj=previous_obj)
+                publisher.publish_obj(self, previous_obj=previous_obj, ignore_tag_creation=ignore_tag_creation)
 
         else:
             if is_published:
@@ -965,18 +970,19 @@ class Chapter(TimeStampedModel):
 
             super(Chapter, self).save(*args, **kwargs)
 
-            # Update related CourseRun instances that include this Chapter, so that, the marketing frontend gets updated
+        # Update related CourseRun instances that include this Chapter, so that, the marketing frontend gets updated
         # at the CourseRun level with correct Chapter includes.
-        for related_courserun in self.course_runs.all():
-            if related_courserun:
-                logger.info(
-                    "Saving related CourseRun `{}` {} since Chapter `{}` {} was updated.".format(
-                        related_courserun.title_override, related_courserun.key, self.title, self.location
+        if is_child_update:
+            for related_courserun in self.course_runs.all():
+                if related_courserun:
+                    logger.info(
+                        "Saving related CourseRun `{}` {} since Chapter `{}` {} was updated.".format(
+                            related_courserun.title_override, related_courserun.key, self.title, self.location
+                        )
                     )
-                )
 
-                related_courserun.status = CourseRunStatus.Unpublished
-                related_courserun.save() # suppress_publication=True)
+                    related_courserun.status = CourseRunStatus.Unpublished
+                    related_courserun.save(ignore_tag_creation=ignore_tag_creation) # suppress_publication=True)
 
 
     def _delete_marketing(self):
@@ -1081,6 +1087,9 @@ class Sequential(TimeStampedModel):
     def save(self, *args, **kwargs):
         suppress_publication = kwargs.pop('suppress_publication', False)
         is_published = kwargs.pop('is_published', False)
+        is_child_update = kwargs.pop('is_child_update', False)
+        ignore_tag_creation = kwargs.pop('ignore_tag_creation', True)
+
         is_publishable = (
             self.course_run.course.partner.has_marketing_site and
             waffle.switch_is_active('publish_course_runs_to_marketing_site') and
@@ -1096,7 +1105,7 @@ class Sequential(TimeStampedModel):
 
             with transaction.atomic():
                 super(Sequential, self).save(*args, **kwargs)
-                publisher.publish_obj(self, previous_obj=previous_obj)
+                publisher.publish_obj(self, previous_obj=previous_obj, ignore_tag_creation=ignore_tag_creation)
 
         else:
             if is_published:
@@ -1106,16 +1115,17 @@ class Sequential(TimeStampedModel):
 
         # Update related Chapter instances that include this Sequential, so that, the marketing frontend gets updated
         # at the Chapter level with correct Sequential includes.
-        for related_chapter in self.chapters.all():
-            if related_chapter:
-                logger.info(
-                    "Saving related Chapter `{}` {} since Sequential `{}` {} was updated.".format(
-                        related_chapter.title, related_chapter.location, self.title, self.location
+        if is_child_update:
+            for related_chapter in self.chapters.all():
+                if related_chapter:
+                    logger.info(
+                        "Saving related Chapter `{}` {} since Sequential `{}` {} was updated.".format(
+                            related_chapter.title, related_chapter.location, self.title, self.location
+                        )
                     )
-                )
 
-                related_chapter.status = ChapterStatus.Unpublished
-                related_chapter.save() # suppress_publication=True)
+                    related_chapter.status = ChapterStatus.Unpublished
+                    related_chapter.save(is_child_update=True, ignore_tag_creation=ignore_tag_creation) # suppress_publication=True)
 
     def _delete_marketing(self):
         publisher = self._locate_publisher(self.course_run.course.partner)  # SequentialMarketingSitePublisher(self.course.partner)
@@ -1169,8 +1179,9 @@ def m2m_tags_changed(sender, **kwargs):
             return
 
     instance = kwargs.get('instance')
+    ignore_tag_creation = False if action == 'post_save' else True
 
-    if isinstance(instance, Sequential):
+    if isinstance(instance, Sequential) and not ignore_tag_creation:
 
         # Do something here.
         logger.info(
@@ -1180,7 +1191,7 @@ def m2m_tags_changed(sender, **kwargs):
         )
 
         instance.status = SequentialStatus.Unpublished
-        instance.save(suppress_publication=False, is_published=False)
+        instance.save(suppress_publication=False, is_published=False, is_child_update=True, ignore_tag_creation=ignore_tag_creation)
 
 
 def m2m_sequentials_changed(sender, **kwargs):
@@ -1199,18 +1210,19 @@ def m2m_sequentials_changed(sender, **kwargs):
             return
 
     instance = kwargs.get('instance')
+    ignore_tag_creation = False if action == 'post_save' else True
 
-    if isinstance(instance, Chapter):
+    if isinstance(instance, Chapter) and not ignore_tag_creation:
 
         # Do something here.
         logger.info(
-            "Sequentials are being saved for Chapter `{}` {}.".format(
+            "Tags are being saved for Chapter `{}` {}.".format(
                 instance.location, instance.title
             )
         )
 
         instance.status = ChapterStatus.Unpublished
-        instance.save(suppress_publication=False, is_published=False)
+        instance.save(suppress_publication=False, is_published=False, ignore_tag_creation=ignore_tag_creation)
 
 
 def m2m_chapters_changed(sender, **kwargs):
@@ -1229,18 +1241,19 @@ def m2m_chapters_changed(sender, **kwargs):
             return
 
     instance = kwargs.get('instance')
+    ignore_tag_creation = False if action == 'post_save' else True
 
-    if isinstance(instance, CourseRun):
+    if isinstance(instance, CourseRun) and not ignore_tag_creation:
 
         # Do something here.
         logger.info(
-            "Chapters are being saved for CourseRun `{}` {}.".format(
+            "Tags are being saved for CourseRun `{}` {}.".format(
                 instance.key, instance.title
             )
         )
 
         instance.status = CourseRunStatus.Unpublished
-        instance.save(suppress_publication=False, is_published=False)
+        instance.save(suppress_publication=False, is_published=False, ignore_tag_creation=ignore_tag_creation)
 
 
 m2m_changed.connect(m2m_tags_changed, sender=Sequential.tags.through)

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -11,6 +11,7 @@ import pytz
 import waffle
 from django.db import models, transaction
 from django.db.models.query_utils import Q
+from django.db.models.signals import m2m_changed
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.fields import AutoSlugField
@@ -493,7 +494,7 @@ class CourseRun(TimeStampedModel):
 
     tags = TaggableManager(
         blank=True,
-        help_text=_('Pick a tag from the suggestions. To make a new tag, add a comma after the tag name.'),
+        help_text=_('These tags are automatically generated from the Chapters that it has references too.'),
     )
 
     chapters = SortedManyToManyField('Chapter', related_name='course_runs')
@@ -710,6 +711,17 @@ class CourseRun(TimeStampedModel):
                     if chapter.max_effort:
                         self.max_effort = self.max_effort + chapter.max_effort
 
+    def _update_tags(self):
+        """ Loops through all referenced Chapters and updates the tags to be relevant for this CourseRun. """
+        tags = []
+        for chapter in self.chapters.all():
+            if chapter.tags:
+                for tag in chapter.tags.names():
+                    if tag not in tags:
+                        tags.append(tag)
+
+        self.tags.set(*tags, clear=True)
+
     def _locate_publisher(self, partner):
         """ Locates the correct Marketing Service for the Partner"""
         switcher = {
@@ -737,6 +749,7 @@ class CourseRun(TimeStampedModel):
         )
 
         self._calculate_effort_duration()
+        self._update_tags()
 
         if is_publishable:
 
@@ -865,6 +878,11 @@ class Chapter(TimeStampedModel):
         help_text=_(
             "Goal description specific for this chapter within the course."))
 
+    tags = TaggableManager(
+        blank=True,
+        help_text=_('These tags are automatically generated from the Sequentials that it has references too.'),
+    )
+
     sequentials = SortedManyToManyField('Sequential', related_name='chapters')
 
     slug = models.CharField(max_length=255, blank=True, null=True, db_index=True)
@@ -890,6 +908,17 @@ class Chapter(TimeStampedModel):
 
                     if sequential.max_effort:
                         self.max_effort = self.max_effort + sequential.max_effort
+
+    def _update_tags(self):
+        """ Loops through all referenced Sequentials and updates the tags to be relevant for this Chapter. """
+        tags = []
+        for sequential in self.sequentials.all():
+            if sequential.tags:
+                for tag in sequential.tags.names():
+                    if tag not in tags:
+                        tags.append(tag)
+
+        self.tags.set(*tags, clear=True)
 
     def _locate_publisher(self, partner):
         """ Locates the correct Marketing Service for the Partner"""
@@ -919,6 +948,7 @@ class Chapter(TimeStampedModel):
         )
 
         self._calculate_effort_duration()
+        self._update_tags()
 
         if is_publishable:
 
@@ -935,17 +965,18 @@ class Chapter(TimeStampedModel):
 
             super(Chapter, self).save(*args, **kwargs)
 
-        # Update related CourseRun instances that include this Chapter, so that, the marketing frontend gets updated
+            # Update related CourseRun instances that include this Chapter, so that, the marketing frontend gets updated
         # at the CourseRun level with correct Chapter includes.
-        for related_courseruns in self.course_runs.all():
-            if related_courseruns:
+        for related_courserun in self.course_runs.all():
+            if related_courserun:
                 logger.info(
                     "Saving related CourseRun `{}` {} since Chapter `{}` {} was updated.".format(
-                        related_courseruns.title_override, related_courseruns.key, self.title, self.location
+                        related_courserun.title_override, related_courserun.key, self.title, self.location
                     )
                 )
-                related_courseruns.status = CourseRunStatus.Unpublished
-                related_courseruns.save() # suppress_publication=True)
+
+                related_courserun.status = CourseRunStatus.Unpublished
+                related_courserun.save() # suppress_publication=True)
 
 
     def _delete_marketing(self):
@@ -1008,6 +1039,11 @@ class Sequential(TimeStampedModel):
         help_text=_('Average number of hours:minutes:seconds [hh:mm:ss] needed to complete this sequential.'))
 
     title = models.CharField(max_length=255, default=None, null=True, blank=True)
+
+    tags = TaggableManager(
+        blank=True,
+        help_text=_('Pick a tag from the suggestions. To make a new tag, add a comma after the tag name.'),
+    )
 
     objectives = SortedManyToManyField('Objective', related_name='sequentials')
 
@@ -1077,9 +1113,9 @@ class Sequential(TimeStampedModel):
                         related_chapter.title, related_chapter.location, self.title, self.location
                     )
                 )
+
                 related_chapter.status = ChapterStatus.Unpublished
                 related_chapter.save() # suppress_publication=True)
-
 
     def _delete_marketing(self):
         publisher = self._locate_publisher(self.course_run.course.partner)  # SequentialMarketingSitePublisher(self.course.partner)
@@ -1115,6 +1151,101 @@ class Sequential(TimeStampedModel):
                 super(Sequential, self).delete(using)
         else:
             super(Sequential, self).delete(using)
+
+
+def m2m_tags_changed(sender, **kwargs):
+    """
+    Update Sequential tags on the publisher after Sequential.save() has been called.
+
+    m2m_changed event gets called after the model.save() is complete.
+    https://docs.djangoproject.com/en/2.1/ref/signals/#m2m-changed
+    """
+    action = kwargs.get('action')
+
+    # We only want to process after 'post_add' or 'post_remove' signals.
+    excluded_signals = ['pre_add', 'pre_remove', 'pre_clear', 'post_clear']
+    for signal in excluded_signals:
+        if signal == action:
+            return
+
+    instance = kwargs.get('instance')
+
+    if isinstance(instance, Sequential):
+
+        # Do something here.
+        logger.info(
+            "Tags are being saved for Sequential `{}` {}.".format(
+                instance.location, instance.title
+            )
+        )
+
+        instance.status = SequentialStatus.Unpublished
+        instance.save(suppress_publication=False, is_published=False)
+
+
+def m2m_sequentials_changed(sender, **kwargs):
+    """
+    Update Chapter tags on the publisher when reference has changed for Sequentials following a Chapter.save() complete.
+
+    m2m_changed event gets called after the model.save() is complete.
+    https://docs.djangoproject.com/en/2.1/ref/signals/#m2m-changed
+    """
+    action = kwargs.get('action')
+
+    # We only want to process after 'post_add' or 'post_remove' signals.
+    excluded_signals = ['pre_add', 'pre_remove', 'pre_clear', 'post_clear']
+    for signal in excluded_signals:
+        if signal == action:
+            return
+
+    instance = kwargs.get('instance')
+
+    if isinstance(instance, Chapter):
+
+        # Do something here.
+        logger.info(
+            "Sequentials are being saved for Chapter `{}` {}.".format(
+                instance.location, instance.title
+            )
+        )
+
+        instance.status = ChapterStatus.Unpublished
+        instance.save(suppress_publication=False, is_published=False)
+
+
+def m2m_chapters_changed(sender, **kwargs):
+    """
+    Update CourseRun tags on the publisher when reference has changed for Chapters following a CourseRun.save() complete.
+
+    m2m_changed event gets called after the model.save() is complete.
+    https://docs.djangoproject.com/en/2.1/ref/signals/#m2m-changed
+    """
+    action = kwargs.get('action')
+
+    # We only want to process after 'post_add' or 'post_remove' signals.
+    excluded_signals = ['pre_add', 'pre_remove', 'pre_clear', 'post_clear']
+    for signal in excluded_signals:
+        if signal == action:
+            return
+
+    instance = kwargs.get('instance')
+
+    if isinstance(instance, CourseRun):
+
+        # Do something here.
+        logger.info(
+            "Chapters are being saved for CourseRun `{}` {}.".format(
+                instance.key, instance.title
+            )
+        )
+
+        instance.status = CourseRunStatus.Unpublished
+        instance.save(suppress_publication=False, is_published=False)
+
+
+m2m_changed.connect(m2m_tags_changed, sender=Sequential.tags.through)
+m2m_changed.connect(m2m_sequentials_changed, sender=Chapter.sequentials.through)
+m2m_changed.connect(m2m_chapters_changed, sender=CourseRun.chapters.through)
 
 
 class Objective(TimeStampedModel):

--- a/course_discovery/apps/course_metadata/publishers_wordpress.py
+++ b/course_discovery/apps/course_metadata/publishers_wordpress.py
@@ -520,7 +520,7 @@ class SequentialMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublis
     post_lookup_field = 'data_locator'
     post_lookup_meta_group = 'open_edx_meta'
 
-    def publish_obj(self, obj, previous_obj=None):
+    def publish_obj(self, obj, previous_obj=None, ignore_tag_creation=True):
         """
         Publish a Sequential to the marketing site.
 
@@ -537,7 +537,7 @@ class SequentialMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublis
         if previous_obj and obj.status != previous_obj.status or previous_obj == None:
             logger.info('Publishing lesson [%s] to marketing site (Wordpress) ...', obj.location)
 
-            post_data = self.serialize_obj(obj)
+            post_data = self.serialize_obj(obj, ignore_tag_creation)
 
             try:
                 post_id = self.post_id(obj)
@@ -555,7 +555,7 @@ class SequentialMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublis
                         ' of previous obj has not changed ...', obj.location, previous_obj.status if previous_obj else "unavailable")
 
 
-    def serialize_obj(self, obj):
+    def serialize_obj(self, obj, ignore_tag_creation=True):
         """
         Serialize the Sequential instance to be published to Wordpress as custom post type 'lesson'.
 
@@ -569,24 +569,25 @@ class SequentialMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublis
         data['title'] = obj.title
         data['slug'] = obj.slug
 
-        tags = []
-        for tag in obj.tags.names():
-            tag_data = {
-                "description" : "",
-                "name" : tag,
-                "slug" : slugify(tag),
-                "meta" : []
-            }
+        if not ignore_tag_creation:
+            tags = []
+            for tag in obj.tags.names():
+                tag_data = {
+                    "description" : "",
+                    "name" : tag,
+                    "slug" : slugify(tag),
+                    "meta" : []
+                }
 
-            try:
-                wp_tag = self.create_tag(tag_data)
-            except (TagCreateError) as error:
-                logger.info('Could not create duplicate tag for [%s] on marketing site (Wordpress) ...', tag)
-                wp_tag = json.loads(error.args[0].get('response_text')).get('data').get('term_id')
+                try:
+                    wp_tag = self.create_tag(tag_data)
+                except (TagCreateError) as error:
+                    logger.info('Could not create duplicate tag for [%s] on marketing site (Wordpress) ...', tag)
+                    wp_tag = json.loads(error.args[0].get('response_text')).get('data').get('term_id')
 
-            if isinstance(wp_tag, int):
-                tags.append(wp_tag)
-        data['edx-tag'] = tags
+                if isinstance(wp_tag, int):
+                    tags.append(wp_tag)
+            data['edx-tag'] = tags
 
         objectives = []
         for objective in obj.objectives.all():
@@ -628,7 +629,7 @@ class ChapterMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublisher
     post_lookup_field = 'data_locator'
     post_lookup_meta_group = 'open_edx_meta'
 
-    def publish_obj(self, obj, previous_obj=None):
+    def publish_obj(self, obj, previous_obj=None, ignore_tag_creation=True):
         """
         Publish a Chapter to the marketing site.
 
@@ -645,7 +646,7 @@ class ChapterMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublisher
         if previous_obj and obj.status != previous_obj.status or previous_obj == None:
             logger.info('Publishing module [%s] to marketing site (Wordpress) ...', obj.location)
 
-            post_data = self.serialize_obj(obj)
+            post_data = self.serialize_obj(obj, ignore_tag_creation)
 
             try:
                 post_id = self.post_id(obj)
@@ -662,7 +663,7 @@ class ChapterMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublisher
             logger.info('Not publishing module [%s] to marketing site (Wordpress) since status [%s]'
                         ' of previous obj has not changed ...', obj.location, previous_obj.status if previous_obj else "unavailable")
 
-    def serialize_obj(self, obj):
+    def serialize_obj(self, obj, ignore_tag_creation=True):
         """
         Serialize the Chapter instance to be published to Wordpress as custom post type 'module'.
 
@@ -676,24 +677,25 @@ class ChapterMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublisher
         data['title'] = obj.title
         data['slug'] = obj.slug
 
-        tags = []
-        for tag in obj.tags.names():
-            tag_data = {
-                "description" : "",
-                "name" : tag,
-                "slug" : slugify(tag),
-                "meta" : []
-            }
+        if not ignore_tag_creation:
+            tags = []
+            for tag in obj.tags.names():
+                tag_data = {
+                    "description" : "",
+                    "name" : tag,
+                    "slug" : slugify(tag),
+                    "meta" : []
+                }
 
-            try:
-                wp_tag = self.create_tag(tag_data)
-            except (TagCreateError) as error:
-                logger.info('Could not create duplicate tag for [%s] on marketing site (Wordpress) ...', tag)
-                wp_tag = json.loads(error.args[0].get('response_text')).get('data').get('term_id')
+                try:
+                    wp_tag = self.create_tag(tag_data)
+                except (TagCreateError) as error:
+                    logger.info('Could not create duplicate tag for [%s] on marketing site (Wordpress) ...', tag)
+                    wp_tag = json.loads(error.args[0].get('response_text')).get('data').get('term_id')
 
-            if isinstance(wp_tag, int):
-                tags.append(wp_tag)
-        data['edx-tag'] = tags
+                if isinstance(wp_tag, int):
+                    tags.append(wp_tag)
+            data['edx-tag'] = tags
 
         sequentials = []
         for sequential in obj.sequentials.all().order_by('chapter_order'):
@@ -740,7 +742,7 @@ class CourseRunMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublish
     post_lookup_field = 'data_locator'
     post_lookup_meta_group = 'open_edx_meta'
 
-    def publish_obj(self, obj, previous_obj=None):
+    def publish_obj(self, obj, previous_obj=None, ignore_tag_creation=True):
         """
         Publish a CourseRun to the marketing site.
 
@@ -757,7 +759,7 @@ class CourseRunMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublish
         if previous_obj and obj.status != previous_obj.status or previous_obj == None:
             logger.info('Publishing course run [%s] to marketing site (Wordpress) ...', obj.key)
 
-            post_data = self.serialize_obj(obj)
+            post_data = self.serialize_obj(obj, ignore_tag_creation)
 
             try:
                 post_id = self.post_id(obj)
@@ -827,7 +829,7 @@ class CourseRunMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublish
     #         **data,
     #     }
 
-    def serialize_obj(self, obj):
+    def serialize_obj(self, obj, ignore_tag_creation=True):
         """
         Serialize the CourseRun instance to be published to Wordpress as custom post type 'course'.
 
@@ -855,24 +857,25 @@ class CourseRunMarketingSiteWordpressPublisher(BaseMarketingSiteWordpressPublish
         #     obj.wordpress_media_id = data['fields']['hero'] = self.create_media(self.serialize_media(obj))
         #     obj.save()
 
-        tags = []
-        for tag in obj.tags.names():
-            tag_data = {
-                "description" : "",
-                "name" : tag,
-                "slug" : slugify(tag),
-                "meta" : []
-            }
+        if not ignore_tag_creation:
+            tags = []
+            for tag in obj.tags.names():
+                tag_data = {
+                    "description" : "",
+                    "name" : tag,
+                    "slug" : slugify(tag),
+                    "meta" : []
+                }
 
-            try:
-                wp_tag = self.create_tag(tag_data)
-            except (TagCreateError) as error:
-                logger.info('Could not create duplicate tag for [%s] on marketing site (Wordpress) ...', tag)
-                wp_tag = json.loads(error.args[0].get('response_text')).get('data').get('term_id')
+                try:
+                    wp_tag = self.create_tag(tag_data)
+                except (TagCreateError) as error:
+                    logger.info('Could not create duplicate tag for [%s] on marketing site (Wordpress) ...', tag)
+                    wp_tag = json.loads(error.args[0].get('response_text')).get('data').get('term_id')
 
-            if isinstance(wp_tag, int):
-                tags.append(wp_tag)
-        data['edx-tag'] = tags
+                if isinstance(wp_tag, int):
+                    tags.append(wp_tag)
+            data['edx-tag'] = tags
 
         chapters = []
         for chapter in obj.chapters.all().order_by('course_order'):


### PR DESCRIPTION
To ensure that the marketing frontend Wordpress can have taggable custom post types of Lessons, Modules, and Courses this update passes tags up to the posts from this `course-discovery` service when tags are added to a particular Sequential.