### PR TITLE
Prevent error when the Course Run `short_description_override` is greater than model limit of 255 characters.

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -514,7 +514,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
             'start': self.parse_date(body['start']),
             'card_image_url': body['media'].get('image', {}).get('raw'),
             'title_override': body['name'],
-            'short_description_override': body['short_description'],
+            'short_description_override': ( body['short_description'][:250] + ' ...' if len(body['short_description']) > 255 else body['short_description'] ),
             'full_description_override': self.api_client.courses(body['id']).get(username=self.username)["overview"],
             'video': self.get_courserun_video(body),
             'status': CourseRunStatus.Unpublished,


### PR DESCRIPTION
The issue is that the LMS Course REST service can send back more than 255 characters in the result but the Course Run model for `course-discovery` can only have 255 character limit. This causes and error when trying to insert more than allowed limit. We postfix the 250 characters with ellipsis '...' ending.